### PR TITLE
fix(bump-version action): update action version

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           token: ${{ secrets.GH_ACTION }}
       - name: Bump version and push tag
-        uses: TriPSs/conventional-changelog-action@3.1.1
+        uses: TriPSs/conventional-changelog-action@v3.1.1
         with:
           github-token: ${{ secrets.GH_ACTION }}
           git-message: 'chore(release): {version}'


### PR DESCRIPTION
XYZ-002

- uses the riPSs/conventional-changelog-action@v3.1.1 action instead of `3.1.1`